### PR TITLE
Allow customizing the message in the header line of the edit buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,6 +54,7 @@ If you want to insert Org-mode source-code or example blocks in comment-sections
 *Fixes:*
 +  Use =setq-local= instead of =org-set-local=
 +  Verify =outline-minor-mode= is active before trying to edit.
++  Display the actual keybinding of =outorg-copy-edits-and-exit= in the header line of the edit buffer.
 
 ** Pre-2.1 changelog
 

--- a/outorg.el
+++ b/outorg.el
@@ -560,7 +560,7 @@ If MODE-NAME is nil, check if Org-Babel identifier of major-mode of current buff
                  (buffer-name
                   (marker-buffer outorg-code-buffer-point-marker))
                  " ] "
-                 "Exit with M-# (Meta-Key and #)")))
+                 (substitute-command-keys "Exit with \\[outorg-copy-edits-and-exit]"))))
 
     ;; Only run the kill-buffer-hooks when the outorg edit buffer is
     ;; being killed. This is because temporary buffers may be created


### PR DESCRIPTION
Hi, it seems that you have been extremely active in releasing new Emacs Lisp packages!

I personally don't use `M-#` for closing edit buffers of outorg. I thought it would be nice to allow customizing the help message in the header line, so I implemented it.