### PR TITLE
Update outshine-hook-function to outshine-mode

### DIFF
--- a/outorg.el
+++ b/outorg.el
@@ -1114,7 +1114,7 @@ outcommented org-mode headers)."
     (while (not (eobp))
       (outline-next-heading)
       (outorg-convert-oldschool-elisp-headline-to-outshine)))
-  (funcall 'outshine-hook-function))
+  (funcall 'outshine-mode))
 
 (defun outorg-convert-oldschool-elisp-headline-to-outshine ()
   "Transform oldschool headline to outshine.


### PR DESCRIPTION
To avoid the warning:
`Warning (emacs): ‘outshine-hook-function’ has been deprecated, use ‘outshine-mode’`

As a result of the Outshine package being updated.