### PR TITLE
Follow org-src-window-setup settings

### DIFF
--- a/outorg.el
+++ b/outorg.el
@@ -1164,9 +1164,7 @@ otherwise the current subtree."
                           (point)))))
 
     ;; Switch to edit buffer
-    (when (one-window-p)
-      (split-window-sensibly (get-buffer-window)))
-    (switch-to-buffer-other-window edit-buffer)
+    (org-src-switch-to-buffer edit-buffer 'edit)
 
     ;; Reinstall outorg-markers
     (outorg-reinstall-markers-in-region (point-min))


### PR DESCRIPTION
Follow org-src-window-setup settings when opening edit buffer.

I tested the changes in my personal config and they seem to work. 

One issue I can imagine is that `org-src-switch-to-buffer (buffer context)` has also the `'exit` and `'save` contexts which are used to restore the window configuration. However, as `outorg` seems to save the current window configuration before the edit buffer is opened and restores it when the edit buffer closes, I think that no issue should arise. 